### PR TITLE
Change PeripheralControllerFactory interface function name

### DIFF
--- a/openTCS-Kernel/src/main/java/org/opentcs/kernel/peripherals/DefaultPeripheralControllerPool.java
+++ b/openTCS-Kernel/src/main/java/org/opentcs/kernel/peripherals/DefaultPeripheralControllerPool.java
@@ -120,7 +120,7 @@ public class DefaultPeripheralControllerPool
     checkArgument(location != null, "No such location: %s", locationRef.getName());
 
     LOG.debug("{}: Attaching controller...", locationRef.getName());
-    PeripheralController controller = controllerFactory.createVehicleController(locationRef,
+    PeripheralController controller = controllerFactory.createPeripheralController(locationRef,
                                                                                 commAdapter);
     poolEntries.put(locationRef, new PoolEntry(locationRef, controller, commAdapter));
     controller.initialize();

--- a/openTCS-Kernel/src/main/java/org/opentcs/kernel/peripherals/DefaultPeripheralControllerPool.java
+++ b/openTCS-Kernel/src/main/java/org/opentcs/kernel/peripherals/DefaultPeripheralControllerPool.java
@@ -121,7 +121,7 @@ public class DefaultPeripheralControllerPool
 
     LOG.debug("{}: Attaching controller...", locationRef.getName());
     PeripheralController controller = controllerFactory.createPeripheralController(locationRef,
-                                                                                commAdapter);
+                                                                                   commAdapter);
     poolEntries.put(locationRef, new PoolEntry(locationRef, controller, commAdapter));
     controller.initialize();
   }

--- a/openTCS-Kernel/src/main/java/org/opentcs/kernel/peripherals/PeripheralControllerFactory.java
+++ b/openTCS-Kernel/src/main/java/org/opentcs/kernel/peripherals/PeripheralControllerFactory.java
@@ -26,6 +26,6 @@ public interface PeripheralControllerFactory {
    * @param commAdapter The communication adapter.
    * @return A new peripheral controller.
    */
-  DefaultPeripheralController createVehicleController(TCSResourceReference<Location> location,
-                                                      PeripheralCommAdapter commAdapter);
+  DefaultPeripheralController createPeripheralController(TCSResourceReference<Location> location,
+                                                         PeripheralCommAdapter commAdapter);
 }


### PR DESCRIPTION
## Description

<!--
Please explain the changes you made here, and why you made them.
If this PR is related to an issue, reference it here.
Note that, with a reference to an issue and/or an expressive commit message (see below), you can usually keep this quite short.
-->
The function name of create DefaultPeripheralController  is wrong in the PeripheralControllerFactory interface file
modify the function name from  createVehicleController to createPeripheralController
