### PR TITLE
Catch exceptions in api calls

### DIFF
--- a/opentcs-kernel-extension-http-services/src/main/java/org/opentcs/kernel/extensions/servicewebapi/v1/PlantModelHandler.java
+++ b/opentcs-kernel-extension-http-services/src/main/java/org/opentcs/kernel/extensions/servicewebapi/v1/PlantModelHandler.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.opentcs.access.to.model.PlantModelCreationTO;
 import org.opentcs.components.kernel.services.PlantModelService;
 import org.opentcs.components.kernel.services.RouterService;
+import org.opentcs.data.ObjectExistsException;
 import org.opentcs.data.ObjectUnknownException;
 import org.opentcs.data.TCSObjectReference;
 import org.opentcs.data.model.Path;
@@ -95,6 +96,7 @@ public class PlantModelHandler {
 
   public void putPlantModel(PlantModelTO putPlantModel)
       throws ObjectUnknownException,
+        ObjectExistsException,
         IllegalArgumentException {
     requireNonNull(putPlantModel, "putPlantModel");
 

--- a/opentcs-kernel-extension-http-services/src/main/java/org/opentcs/kernel/extensions/servicewebapi/v1/V1RequestHandler.java
+++ b/opentcs-kernel-extension-http-services/src/main/java/org/opentcs/kernel/extensions/servicewebapi/v1/V1RequestHandler.java
@@ -134,6 +134,24 @@ public class V1RequestHandler
   public void addRoutes(Service service) {
     requireNonNull(service, "service");
 
+    service.exception(
+        IllegalArgumentException.class,
+        (exception, request, response) -> {
+          response.status(400);
+          response.type("application/json");
+          response.body("Bad request: " + exception.getMessage());
+        }
+    );
+
+    service.exception(
+        Exception.class,
+        (exception, request, response) -> {
+          response.status(500);
+          response.type("application/json");
+          response.body("Internal server error: " + exception.getMessage());
+        }
+    );
+
     service.get(
         "/events",
         this::handleGetEvents

--- a/opentcs-kernel-extension-http-services/src/main/java/org/opentcs/kernel/extensions/servicewebapi/v1/V1RequestHandler.java
+++ b/opentcs-kernel-extension-http-services/src/main/java/org/opentcs/kernel/extensions/servicewebapi/v1/V1RequestHandler.java
@@ -515,6 +515,7 @@ public class V1RequestHandler
 
   private Object handlePutPlantModel(Request request, Response response)
       throws ObjectUnknownException,
+        ObjectExistsException,
         IllegalArgumentException {
     plantModelHandler.putPlantModel(jsonBinder.fromJson(request.body(), PlantModelTO.class));
     response.type(HttpConstants.CONTENT_TYPE_TEXT_PLAIN_UTF8);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: The openTCS Authors
SPDX-License-Identifier: CC-BY-4.0
-->

## Description
Implement exception handler in request handler
    
Internal exceptions could crash the server on bad api calls.
Implement two exception handlers, catching
 * general exceptions, returning 500 internal server error
 * invalid usage, returning 400


...

## Checklist

- [check] You have the right to contribute the code/documentation/assets to this project, and you agree to contribute it under the terms of the project's license(s).
- [check] All changes have been made on a separate branch (not master) in a fork.
- [check] The whole project compiles correctly and all tests pass, i.e. `gradlew clean build` succeeds with the changes made, and without unavoidable compiler/toolchain warnings.
- [-] New tests covering the change have been added, if it is possible / makes sense.
- [na] The documentation has been extended, if necessary.
- [check] The PR contains a proposal for a _well-formed_ commit message that mentions all authors who contributed to the PR.
      (The commits in the PR will be squashed into one commit on the base branch, and your proposed message is intended to be used for this commit. See below for a template you can use for the message. See [this blog post](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) and [this one](https://chris.beams.io/posts/git-commit/#seven-rules) for more on well-formed commit messages.)

## Proposed squash commit message
Implement exception handler in request handler
    
Internal exceptions could crash the server on bad api calls.
Implement two exception handlers, catching
 * general exceptions, returning 500 internal server error
 * invalid api use, returning 400

Co-authored-by: J.Thraen, johannes.thraen@gmail.com
